### PR TITLE
Check unconditionally for talking state and disable if talking is true

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
@@ -283,24 +283,24 @@ public class PlumbleActivity extends ActionBarActivity implements ListView.OnIte
             }
 
             @Override
-            public void onDrawerOpened(View drawerView) {
-                supportInvalidateOptionsMenu();
+            public void onDrawerStateChanged(int newState) {
+                super.onDrawerStateChanged(newState);
+
+                try {
+                    if (getService().isConnected() && getService().isTalking()) {
+                        getService().setTalkingState(false);
+                    }
+                } catch (RemoteException e) {
+                    e.printStackTrace();
+                }
             }
 
             @Override
-            public void onDrawerStateChanged(int newState) {
-                if (newState == DrawerLayout.STATE_DRAGGING) {
-                    try {
-                        // Workaround PTT staying on when the drawer is opened.
-                        if (getService().isConnected() && getService().isTalking()) {
-                            getService().setTalkingState(false);
-                        }
-                    } catch (RemoteException e) {
-                        e.printStackTrace();
-                    }
-                }
+            public void onDrawerOpened(View drawerView) {
+                supportInvalidateOptionsMenu();
             }
         };
+
         mDrawerLayout.setDrawerListener(mDrawerToggle);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);


### PR DESCRIPTION
This code is to avoid a hang of ptt when ptt is pressed at left edge where also drawer is opened. In this case ptt hangs in talking state. Solution is to check for talking state on any action on the drawer and disable talking it there is. PTT check must be done unconditionally in callback function.