### PR TITLE
Shorten URLs to just their domain name in text-to-speech

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -80,6 +80,9 @@ public class Settings {
     public static final String PREF_USE_TTS = "useTts";
     public static final Boolean DEFAULT_USE_TTS = true;
 
+    public static final String PREF_SHORT_TTS_MESSAGES = "shortTtsMessages";
+    public static final boolean DEFAULT_SHORT_TTS_MESSAGES = false;
+
     public static final String PREF_AUTO_RECONNECT = "autoReconnect";
     public static final Boolean DEFAULT_AUTO_RECONNECT = true;
 
@@ -296,6 +299,10 @@ public class Settings {
 
     public boolean isTextToSpeechEnabled() {
         return preferences.getBoolean(PREF_USE_TTS, DEFAULT_USE_TTS);
+    }
+
+    public boolean isShortTextToSpeechMessagesEnabled() {
+        return preferences.getBoolean(PREF_SHORT_TTS_MESSAGES, DEFAULT_SHORT_TTS_MESSAGES);
     }
 
     public boolean isAutoReconnectEnabled() {

--- a/app/src/main/res/values/preference.xml
+++ b/app/src/main/res/values/preference.xml
@@ -96,6 +96,8 @@
 	<string name="hidePttSum">Hides the push to talk button when in push to talk mode. Useful if you use hot corners or a hardware key exclusively.</string>
     <string name="useTts">Text-to-Speech</string>
     <string name="useTtsSum">Enable Text-to-Speech for incoming messages.</string>
+    <string name="shortTtsMessages">Short Text-to-Speech messages</string>
+    <string name="shortTtsMessagesSum">Shorten Text-to-Speech messages by replacing links with their domain names.</string>
     <string name="togglePtt">Toggle Push to Talk</string>
     <string name="togglePttSum">Toggles push to talk on and off when pressed.</string>
     <string name="autoReconnect">Auto Reconnect</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="chat_message_tree">(Tree)</string>
     <string name="chat_message_channel">(Channel)</string>
     <string name="chat_message_to">%1$s → %2$s</string>
+    <string name="chat_message_tts_short_link">(Link to %1$s)</string>
 
     <!-- User menu -->
     <string name="user_menu_admin">Admin</string>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -37,6 +37,12 @@
         android:title="@string/useTts" />
 
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="shortTtsMessages"
+        android:summary="@string/shortTtsMessagesSum"
+        android:title="@string/shortTtsMessages" />
+
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="load_images"
         android:summary="@string/loadImagesSum"


### PR DESCRIPTION
This was really annoying when someone pasted a link to an image hosted
on a CDN that used hashes for filenames.