### PR TITLE
Properly parse / strip HTML in messages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile 'com.android.support:cardview-v7:21.+'
     compile 'com.android.support:palette-v7:21.+'
     compile 'com.android.support:recyclerview-v7:21.+'
+    compile 'org.jsoup:jsoup:1.7.2'
 }
 
 

--- a/app/src/main/java/com/morlunk/mumbleclient/util/HtmlUtils.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/util/HtmlUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014 Andrew Comminos
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.morlunk.mumbleclient.util;
+
+import android.text.TextUtils;
+
+import java.net.URI;
+
+public class HtmlUtils {
+    /**
+     * Tries to get the link's hostname, returns `null` if not a valid URL.
+     * @param link link to get the hostname of
+     * @return String?
+     */
+    public static String getHostnameFromLink(String link) {
+        // Cheap pre-check
+        if (link.contains("://")) {
+            try {
+                URI maybeURI = URI.create(link);
+                if (!TextUtils.isEmpty(maybeURI.getHost())) {
+                    return maybeURI.getHost();
+                }
+            } catch (IllegalArgumentException e) {
+                // not a valid URI
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Now we use an actual HTML parser to parse message bodies, so we can handle things like `&quot;`, `&loz;` and `&#x0A;` properly. 

Not married to using JSoup for this, but it's the library that made it easiest to modify the tree in place, then get the plaintext version. Any thoughts?